### PR TITLE
Prefer user cert over proxy, add some more methods

### DIFF
--- a/dmwmclient/__init__.py
+++ b/dmwmclient/__init__.py
@@ -5,6 +5,7 @@ from .unified import Unified
 from .dbs import DBS
 from .reqmgr import ReqMgr
 from .dynamo import Dynamo
+from .mcm import McM
 
 
 class Client:
@@ -15,6 +16,7 @@ class Client:
         self.dbs = DBS(self.baseclient)
         self.reqmgr = ReqMgr(self.baseclient)
         self.dynamo = Dynamo(self.baseclient)
+        self.mcm = McM(self.baseclient)
 
 
 __all__ = [

--- a/dmwmclient/__init__.py
+++ b/dmwmclient/__init__.py
@@ -8,8 +8,8 @@ from .dynamo import Dynamo
 
 
 class Client:
-    def __init__(self):
-        self.baseclient = RESTClient()
+    def __init__(self, usercert=None):
+        self.baseclient = RESTClient(usercert=usercert)
         self.datasvc = DataSvc(self.baseclient)
         self.unified = Unified(self.baseclient)
         self.dbs = DBS(self.baseclient)

--- a/dmwmclient/cli/__init__.py
+++ b/dmwmclient/cli/__init__.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 from .. import Client
-from ..restclient import _proxycert
+from ..restclient import locate_proxycert
 from .shell import Shell
 from .test import Test
 from .unified import UnifiedTransferStatus
@@ -30,7 +30,7 @@ def cli():
     loglevel = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
     logging.basicConfig(level=loglevel[min(2, args.verbose)])
 
-    client = Client(usercert=_proxycert() if args.proxy else None)
+    client = Client(usercert=locate_proxycert() if args.proxy else None)
 
     if hasattr(args, "command"):
         args.command(client=client)

--- a/dmwmclient/cli/__init__.py
+++ b/dmwmclient/cli/__init__.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 from .. import Client
+from ..restclient import _proxycert
 from .shell import Shell
 from .test import Test
 from .unified import UnifiedTransferStatus
@@ -14,6 +15,11 @@ def cli():
     parser.add_argument(
         "-v", "--verbose", action="count", default=0, help="Verbosity",
     )
+    parser.add_argument(
+        "--proxy",
+        action="store_true",
+        help="Prefer using a user proxy over user certificate",
+    )
     subparsers = parser.add_subparsers(help="sub-command help")
     Shell.register(subparsers)
     Test.register(subparsers)
@@ -24,7 +30,7 @@ def cli():
     loglevel = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
     logging.basicConfig(level=loglevel[min(2, args.verbose)])
 
-    client = Client()
+    client = Client(usercert=_proxycert() if args.proxy else None)
 
     if hasattr(args, "command"):
         args.command(client=client)

--- a/dmwmclient/mcm.py
+++ b/dmwmclient/mcm.py
@@ -1,0 +1,21 @@
+import httpx
+
+
+class McM:
+    """McM client
+
+    """
+
+    defaults = {
+        # McM REST endpoint URL with trailing slash
+        "mcm_base": "https://cms-pdmv.cern.ch/mcm/",
+    }
+
+    def __init__(self, client, mcm_base=None):
+        if mcm_base is None:
+            mcm_base = McM.defaults["mcm_base"]
+        self.client = client
+        self.baseurl = httpx.URL(mcm_base)
+
+    async def search(self, **params):
+        return await self.client.getjson(url=self.baseurl.join("search"), params=params)

--- a/dmwmclient/restclient.py
+++ b/dmwmclient/restclient.py
@@ -10,6 +10,17 @@ from . import __version__
 logger = logging.getLogger(__name__)
 
 
+def _proxycert():
+    """Find a user proxy"""
+    path = os.getenv("X509_USER_PROXY")
+    if path is not None:
+        return path
+    path = "/tmp/x509up_u%d" % os.getuid()
+    if os.path.exists(path):
+        return path
+    return None
+
+
 def _defaultcert():
     """Find a suitable user certificate from the usual locations
 
@@ -22,11 +33,8 @@ def _defaultcert():
     )
     if os.path.exists(path[0]) and os.path.exists(path[1]):
         return path
-    path = os.getenv("X509_USER_PROXY")
+    path = _proxycert()
     if path is not None:
-        return path
-    path = "/tmp/x509up_u%d" % os.getuid()
-    if os.path.exists(path):
         return path
     raise RuntimeError("Could not identify an appropriate default user certificate")
 

--- a/dmwmclient/restclient.py
+++ b/dmwmclient/restclient.py
@@ -10,7 +10,7 @@ from . import __version__
 logger = logging.getLogger(__name__)
 
 
-def _proxycert():
+def locate_proxycert():
     """Find a user proxy"""
     path = os.getenv("X509_USER_PROXY")
     if path is not None:
@@ -33,7 +33,7 @@ def _defaultcert():
     )
     if os.path.exists(path[0]) and os.path.exists(path[1]):
         return path
-    path = _proxycert()
+    path = locate_proxycert()
     if path is not None:
         return path
     raise RuntimeError("Could not identify an appropriate default user certificate")


### PR DESCRIPTION
Need user cert for any CERN SSO calls, so better to have that default. Proxy can be used by passing appropriate argument to `Client` constructor.